### PR TITLE
1,添加对表格的默认排序。2，修复表名与PO类名映射转换时，使用骆驼法则没有前期校验的问题。

### DIFF
--- a/src/main/java/com/zzg/mybatis/generator/util/DbUtil.java
+++ b/src/main/java/com/zzg/mybatis/generator/util/DbUtil.java
@@ -71,6 +71,10 @@ public class DbUtil {
 		    while (rs.next()) {
 			    tables.add(rs.getString(3));
 		    }
+
+		    if (tables.size()>1) {
+		    	Collections.sort(tables);
+			}
 		    return tables;
 	    } finally {
 	    	connection.close();

--- a/src/main/java/com/zzg/mybatis/generator/util/MyStringUtils.java
+++ b/src/main/java/com/zzg/mybatis/generator/util/MyStringUtils.java
@@ -14,21 +14,27 @@ public class MyStringUtils {
      */
     public static String dbStringToCamelStyle(String str) {
         if (str != null) {
-            str = str.toLowerCase();
-            StringBuilder sb = new StringBuilder();
-            sb.append(String.valueOf(str.charAt(0)).toUpperCase());
-            for (int i = 1; i < str.length(); i++) {
-                char c = str.charAt(i);
-                if (c != '_') {
-                    sb.append(c);
-                } else {
-                    if (i + 1 < str.length()) {
-                        sb.append(String.valueOf(str.charAt(i + 1)).toUpperCase());
-                        i++;
+            if (str.contains("_")) {
+                str = str.toLowerCase();
+                StringBuilder sb = new StringBuilder();
+                sb.append(String.valueOf(str.charAt(0)).toUpperCase());
+                for (int i = 1; i < str.length(); i++) {
+                    char c = str.charAt(i);
+                    if (c != '_') {
+                        sb.append(c);
+                    } else {
+                        if (i + 1 < str.length()) {
+                            sb.append(String.valueOf(str.charAt(i + 1)).toUpperCase());
+                            i++;
+                        }
                     }
                 }
+                return sb.toString();
+            } else {
+                String firstChar = String.valueOf(str.charAt(0)).toUpperCase();
+                String otherChars = str.substring(1);
+                return firstChar + otherChars;
             }
-            return sb.toString();
         }
         return null;
     }


### PR DESCRIPTION
1,添加对表格的默认排序。
2，修复表名与PO类名映射转换时，使用骆驼法则没有前期校验的问题。
修复了由表名转PO对象类时，一些骆驼法则使用上，造成大小写的异常问题。如，表名：TUserAccount ,之前转换为了：Tuseraccount。这并非想要的，理想应该转为：TUserAccount