### PR TITLE
处理数据库字段为关键词的情况

### DIFF
--- a/src/main/java/com/zzg/mybatis/generator/bridge/MybatisGeneratorBridge.java
+++ b/src/main/java/com/zzg/mybatis/generator/bridge/MybatisGeneratorBridge.java
@@ -159,6 +159,10 @@ public class MybatisGeneratorBridge {
                 context.addPluginConfiguration(pluginConfiguration);
             }
         }
+        // 设置property，当字段有关键词的时候，就会自动加上分隔符
+        context.addProperty("autoDelimitKeywords","true");
+        context.addProperty("beginningDelimiter","`");
+        context.addProperty("endingDelimiter","`");
         context.setTargetRuntime("MyBatis3");
 
         List<String> warnings = new ArrayList<>();


### PR DESCRIPTION
添加property配置，当字段是关键词时，就会生成单引号分隔符，对关键词字段处理，防止报错；