### PR TITLE
增加OverSSH功能

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,11 @@
             <artifactId>slf4j-api</artifactId>
             <version>1.7.25</version>
         </dependency>
+        <dependency>
+            <groupId>com.jcraft</groupId>
+            <artifactId>jsch</artifactId>
+            <version>0.1.54</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/zzg/mybatis/generator/controller/DbConnectionController.java
+++ b/src/main/java/com/zzg/mybatis/generator/controller/DbConnectionController.java
@@ -1,10 +1,11 @@
 package com.zzg.mybatis.generator.controller;
 
-import com.zzg.mybatis.generator.exception.DbDriverLoadingException;
+import com.jcraft.jsch.Session;
 import com.zzg.mybatis.generator.model.DatabaseConfig;
 import com.zzg.mybatis.generator.util.ConfigHelper;
 import com.zzg.mybatis.generator.util.DbUtil;
 import com.zzg.mybatis.generator.view.AlertUtil;
+import javafx.event.ActionEvent;
 import javafx.fxml.FXML;
 import javafx.scene.control.ChoiceBox;
 import javafx.scene.control.TextField;
@@ -17,113 +18,130 @@ import java.util.ResourceBundle;
 
 public class DbConnectionController extends BaseFXController {
 
-	private static final Logger _LOG = LoggerFactory.getLogger(DbConnectionController.class);
+    private static final Logger _LOG = LoggerFactory.getLogger(DbConnectionController.class);
 
-	@FXML
-	private TextField nameField;
-	@FXML
-	private TextField hostField;
-	@FXML
-	private TextField portField;
-	@FXML
-	private TextField userNameField;
-	@FXML
-	private TextField passwordField;
-	@FXML
-	private TextField schemaField;
-	@FXML
-	private ChoiceBox<String> encodingChoice;
-	@FXML
-	private ChoiceBox<String> dbTypeChoice;
-	private MainUIController mainUIController;
-	private boolean isUpdate = false;
-	private Integer primayKey;
+    @FXML
+    private TextField nameField;
+    @FXML
+    private TextField hostField;
+    @FXML
+    private TextField portField;
+    @FXML
+    private TextField userNameField;
+    @FXML
+    private TextField passwordField;
+    @FXML
+    private TextField schemaField;
+    @FXML
+    private ChoiceBox<String> encodingChoice;
+    @FXML
+    private ChoiceBox<String> dbTypeChoice;
+    private MainUIController mainUIController;
+    private boolean isUpdate = false;
+    private Integer primayKey;
+    private DatabaseConfig databaseConfig;
 
 
-	@Override
-	public void initialize(URL location, ResourceBundle resources) {
-	}
+    @Override
+    public void initialize(URL location, ResourceBundle resources) {
+    }
 
-	@FXML
-	void saveConnection() {
-		DatabaseConfig config = extractConfigForUI();
-		if (config == null) {
-			return;
-		}
-		try {
-			ConfigHelper.saveDatabaseConfig(this.isUpdate, primayKey, config);
-			getDialogStage().close();
-			mainUIController.loadLeftDBTree();
-		} catch (Exception e) {
-			_LOG.error(e.getMessage(), e);
-			AlertUtil.showErrorAlert(e.getMessage());
-		}
-	}
+    @FXML
+    void saveConnection() {
+        DatabaseConfig config = extractConfigForUI();
+        if (config == null) {
+            return;
+        }
+        try {
+            ConfigHelper.saveDatabaseConfig(this.isUpdate, primayKey, config);
+            getDialogStage().close();
+            mainUIController.loadLeftDBTree();
+        } catch (Exception e) {
+            _LOG.error(e.getMessage(), e);
+            AlertUtil.showErrorAlert(e.getMessage());
+        }
+    }
 
-	@FXML
-	void testConnection() {
-		DatabaseConfig config = extractConfigForUI();
-		if (config == null) {
-			return;
-		}
-		try {
-			DbUtil.getConnection(config);
-			AlertUtil.showInfoAlert("连接成功");
-		} catch (DbDriverLoadingException e){
-			_LOG.error("{}", e);
-			AlertUtil.showWarnAlert("连接失败, "+e.getMessage());
-		} catch (Exception e) {
-			_LOG.error(e.getMessage(), e);
-			AlertUtil.showWarnAlert("连接失败");
-		}
+    @FXML
+    void testConnection() {
+        DatabaseConfig config = extractConfigForUI();
+        if (config == null) {
+            return;
+        }
+        Session sshSession = DbUtil.getSSHSession(config);
+        try {
+            DbUtil.engagePortForwarding(sshSession, config);
+            DbUtil.getConnection(config);
+            AlertUtil.showInfoAlert("连接成功");
+            DbUtil.shutdownPortForwarding(sshSession);
+        } catch (RuntimeException e) {
+            _LOG.error("", e);
+            AlertUtil.showWarnAlert("连接失败, " + e.getMessage());
+        } catch (Exception e) {
+            _LOG.error(e.getMessage(), e);
+            AlertUtil.showWarnAlert("连接失败");
+        }
+    }
 
-	}
+    @FXML
+    void cancel() {
+        getDialogStage().close();
+    }
 
-	@FXML
-	void cancel() {
-		getDialogStage().close();
-	}
+    void setMainUIController(MainUIController controller) {
+        this.mainUIController = controller;
+    }
 
-	void setMainUIController(MainUIController controller) {
-		this.mainUIController = controller;
-	}
+    private DatabaseConfig extractConfigForUI() {
+        String name = nameField.getText();
+        String host = hostField.getText();
+        String port = portField.getText();
+        String userName = userNameField.getText();
+        String password = passwordField.getText();
+        String encoding = encodingChoice.getValue();
+        String dbType = dbTypeChoice.getValue();
+        String schema = schemaField.getText();
+        DatabaseConfig config = new DatabaseConfig();
+        config.setName(name);
+        config.setDbType(dbType);
+        config.setHost(host);
+        config.setPort(port);
+        config.setUsername(userName);
+        config.setPassword(password);
+        config.setSchema(schema);
+        config.setEncoding(encoding);
+        if (this.databaseConfig != null) {
+            config.setSshUser(this.databaseConfig.getSshUser());
+            config.setSshPassword(this.databaseConfig.getSshPassword());
+            config.setLport(this.databaseConfig.getLport());
+            config.setRport(this.databaseConfig.getRport());
+            config.setSshHost(this.databaseConfig.getSshHost());
+            config.setSshPort(this.databaseConfig.getSshPort());
+        }
+        if (StringUtils.isAnyEmpty(name, host, port, userName, encoding, dbType, schema)) {
+            AlertUtil.showWarnAlert("密码以外其他字段必填");
+            return null;
+        }
+        return config;
+    }
 
-	private DatabaseConfig extractConfigForUI() {
-		String name = nameField.getText();
-		String host = hostField.getText();
-		String port = portField.getText();
-		String userName = userNameField.getText();
-		String password = passwordField.getText();
-		String encoding = encodingChoice.getValue();
-		String dbType = dbTypeChoice.getValue();
-		String schema = schemaField.getText();
-		DatabaseConfig config = new DatabaseConfig();
-		config.setName(name);
-		config.setDbType(dbType);
-		config.setHost(host);
-		config.setPort(port);
-		config.setUsername(userName);
-		config.setPassword(password);
-		config.setSchema(schema);
-		config.setEncoding(encoding);
-		if (StringUtils.isAnyEmpty(name, host, port, userName, encoding, dbType, schema)) {
-			AlertUtil.showWarnAlert("密码以外其他字段必填");
-			return null;
-		}
-		return config;
-	}
+    public void setConfig(DatabaseConfig config) {
+        isUpdate = true;
+        primayKey = config.getId(); // save id for update config
+        nameField.setText(config.getName());
+        hostField.setText(config.getHost());
+        portField.setText(config.getPort());
+        userNameField.setText(config.getUsername());
+        passwordField.setText(config.getPassword());
+        encodingChoice.setValue(config.getEncoding());
+        dbTypeChoice.setValue(config.getDbType());
+        schemaField.setText(config.getSchema());
+        this.databaseConfig = config;
+    }
 
-	public void setConfig(DatabaseConfig config) {
-		isUpdate = true;
-		primayKey = config.getId(); // save id for update config
-		nameField.setText(config.getName());
-		hostField.setText(config.getHost());
-		portField.setText(config.getPort());
-		userNameField.setText(config.getUsername());
-		passwordField.setText(config.getPassword());
-		encodingChoice.setValue(config.getEncoding());
-		dbTypeChoice.setValue(config.getDbType());
-		schemaField.setText(config.getSchema());
-	}
-
+    public void overSSH(ActionEvent actionEvent) {
+        OverSshController overSshController = (OverSshController) loadFXMLPage("OverSSH设置", FXMLPage.OVERSSH_CONFIG, false);
+        overSshController.setDbConnectionController(this);
+        overSshController.setDbConnectionConfig(databaseConfig);
+    }
 }

--- a/src/main/java/com/zzg/mybatis/generator/controller/FXMLPage.java
+++ b/src/main/java/com/zzg/mybatis/generator/controller/FXMLPage.java
@@ -9,7 +9,9 @@ public enum FXMLPage {
 
     NEW_CONNECTION("fxml/newConnection.fxml"),
     SELECT_TABLE_COLUMN("fxml/selectTableColumn.fxml"),
-    GENERATOR_CONFIG("fxml/generatorConfigs.fxml"),;
+    GENERATOR_CONFIG("fxml/generatorConfigs.fxml"),
+    OVERSSH_CONFIG("fxml/overssh.fxml"),
+    ;
 
     private String fxml;
 

--- a/src/main/java/com/zzg/mybatis/generator/controller/OverSshController.java
+++ b/src/main/java/com/zzg/mybatis/generator/controller/OverSshController.java
@@ -7,8 +7,10 @@ import com.zzg.mybatis.generator.util.DbUtil;
 import com.zzg.mybatis.generator.view.AlertUtil;
 import javafx.event.ActionEvent;
 import javafx.fxml.FXML;
+import javafx.scene.control.Label;
 import javafx.scene.control.PasswordField;
 import javafx.scene.control.TextField;
+import javafx.scene.paint.Paint;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -36,6 +38,8 @@ public class OverSshController extends BaseFXController {
     private TextField lportField;
     @FXML
     private TextField rportField;
+    @FXML
+    private Label note;
 
     private DbConnectionController dbConnectionController;
 
@@ -50,6 +54,9 @@ public class OverSshController extends BaseFXController {
     }
 
     public void setDbConnectionConfig(DatabaseConfig extractConfigForUI) {
+        if (extractConfigForUI == null) {
+            return;
+        }
         this.databaseConfig = extractConfigForUI;
         this.sshdPortField.setText(this.databaseConfig.getSshPort());
         this.hostField.setText(this.databaseConfig.getSshHost());
@@ -63,6 +70,23 @@ public class OverSshController extends BaseFXController {
         }
         if (StringUtils.isBlank(this.rportField.getText())) {
             this.rportField.setText(this.databaseConfig.getPort());
+        }
+        checkInput();
+    }
+
+    @FXML
+    public void checkInput() {
+        DatabaseConfig databaseConfig = extractConfigFromUi();
+        if (StringUtils.isBlank(databaseConfig.getSshHost())
+                || StringUtils.isBlank(databaseConfig.getSshPort())
+                || StringUtils.isBlank(databaseConfig.getSshUser())
+                || StringUtils.isBlank(databaseConfig.getSshPassword())
+        ) {
+            note.setText("当前输入不完整，默认不生效");
+            note.setTextFill(Paint.valueOf("#ff666f"));
+        }else {
+            note.setText("当前配置生效");
+            note.setTextFill(Paint.valueOf("#5da355"));
         }
     }
 
@@ -85,6 +109,17 @@ public class OverSshController extends BaseFXController {
         databaseConfig.setRport(this.rportField.getText());
         databaseConfig.setSshUser(this.sshUserField.getText());
         databaseConfig.setSshPassword(this.sshPasswordField.getText());
+        if (StringUtils.isAnyEmpty(
+                databaseConfig.getName(),
+                databaseConfig.getHost(),
+                databaseConfig.getPort(),
+                databaseConfig.getUsername(),
+                databaseConfig.getEncoding(),
+                databaseConfig.getDbType(),
+                databaseConfig.getSchema())) {
+            getDialogStage().close();
+            return;
+        }
         this.dbConnectionController.saveConnection();
     }
 

--- a/src/main/java/com/zzg/mybatis/generator/controller/OverSshController.java
+++ b/src/main/java/com/zzg/mybatis/generator/controller/OverSshController.java
@@ -1,0 +1,131 @@
+package com.zzg.mybatis.generator.controller;
+
+import com.jcraft.jsch.JSchException;
+import com.jcraft.jsch.Session;
+import com.zzg.mybatis.generator.model.DatabaseConfig;
+import com.zzg.mybatis.generator.util.DbUtil;
+import com.zzg.mybatis.generator.view.AlertUtil;
+import javafx.event.ActionEvent;
+import javafx.fxml.FXML;
+import javafx.scene.control.PasswordField;
+import javafx.scene.control.TextField;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.URL;
+import java.util.ResourceBundle;
+import java.util.concurrent.*;
+
+/**
+ * Project: mybatis-generator-gui
+ *
+ * @author slankka on 2018/12/30.
+ */
+public class OverSshController extends BaseFXController {
+    private Logger logger = LoggerFactory.getLogger(OverSshController.class);
+    @FXML
+    public TextField sshUserField;
+    @FXML
+    public PasswordField sshPasswordField;
+    @FXML
+    private TextField hostField;
+    @FXML
+    private TextField sshdPortField;
+    @FXML
+    private TextField lportField;
+    @FXML
+    private TextField rportField;
+
+    private DbConnectionController dbConnectionController;
+
+    private DatabaseConfig databaseConfig;
+
+    public void setDbConnectionController(DbConnectionController dbConnectionController) {
+        this.dbConnectionController = dbConnectionController;
+    }
+
+    @Override
+    public void initialize(URL location, ResourceBundle resources) {
+    }
+
+    public void setDbConnectionConfig(DatabaseConfig extractConfigForUI) {
+        this.databaseConfig = extractConfigForUI;
+        this.sshdPortField.setText(this.databaseConfig.getSshPort());
+        this.hostField.setText(this.databaseConfig.getSshHost());
+        this.lportField.setText(this.databaseConfig.getLport());
+        this.rportField.setText(this.databaseConfig.getRport());
+        this.sshUserField.setText(this.databaseConfig.getSshUser());
+        this.sshPasswordField.setText(this.databaseConfig.getSshPassword());
+        //例如：默认从本机的 3306 -> 转发到 3306
+        if (StringUtils.isBlank(this.lportField.getText())){
+            this.lportField.setText(this.databaseConfig.getPort());
+        }
+        if (StringUtils.isBlank(this.rportField.getText())) {
+            this.rportField.setText(this.databaseConfig.getPort());
+        }
+    }
+
+    private DatabaseConfig extractConfigFromUi() {
+        DatabaseConfig config = new DatabaseConfig();
+        config.setSshHost(this.hostField.getText());
+        config.setSshPort(this.sshdPortField.getText());
+        config.setLport(this.lportField.getText());
+        config.setRport(this.rportField.getText());
+        config.setSshUser(this.sshUserField.getText());
+        config.setSshPassword(this.sshPasswordField.getText());
+        return config;
+    }
+
+    @FXML
+    public void saveConfig(ActionEvent actionEvent) {
+        databaseConfig.setSshHost(this.hostField.getText());
+        databaseConfig.setSshPort(this.sshdPortField.getText());
+        databaseConfig.setLport(this.lportField.getText());
+        databaseConfig.setRport(this.rportField.getText());
+        databaseConfig.setSshUser(this.sshUserField.getText());
+        databaseConfig.setSshPassword(this.sshPasswordField.getText());
+        this.dbConnectionController.saveConnection();
+    }
+
+    @FXML
+    public void testSSH(ActionEvent actionEvent) {
+        Session session = DbUtil.getSSHSession(extractConfigFromUi());
+        if (session == null) {
+            AlertUtil.showErrorAlert("请检查主机，端口，用户名，以及密码是否填写正确");
+            return;
+        }
+        ExecutorService executorService = Executors.newSingleThreadExecutor();
+        Future<?> result = executorService.submit(() -> {
+            try {
+                session.connect();
+            } catch (JSchException e) {
+                logger.error("Connect Over SSH failed", e);
+                throw new RuntimeException(e.getMessage());
+            }
+        });
+        executorService.shutdown();
+        try {
+            boolean b = executorService.awaitTermination(5, TimeUnit.SECONDS);
+            if (!b) {
+                throw new TimeoutException("连接超时");
+            }
+            result.get();
+            AlertUtil.showInfoAlert("连接SSH服务器成功，恭喜你可以使用OverSSH功能");
+        } catch (Exception e) {
+            AlertUtil.showErrorAlert("请检查主机，端口，用户名，以及密码是否填写正确: " + e.getMessage());
+        }finally {
+            DbUtil.shutdownPortForwarding(session);
+        }
+    }
+
+    @FXML
+    public void reset(ActionEvent actionEvent) {
+        this.sshUserField.clear();
+        this.sshPasswordField.clear();
+        this.sshdPortField.clear();
+        this.hostField.clear();
+        this.lportField.clear();
+        this.rportField.clear();
+    }
+}

--- a/src/main/java/com/zzg/mybatis/generator/model/DatabaseConfig.java
+++ b/src/main/java/com/zzg/mybatis/generator/model/DatabaseConfig.java
@@ -30,6 +30,18 @@ public class DatabaseConfig {
 
 	private String encoding;
 
+    private String lport;
+
+    private String rport;
+
+    private String sshPort;
+
+    private String sshHost;
+
+    private String sshUser;
+
+    private String sshPassword;
+
 	public Integer getId() {
 		return id;
 	}
@@ -102,26 +114,99 @@ public class DatabaseConfig {
 		this.dbType = dbType;
 	}
 
+    public String getLport() {
+        return lport;
+    }
+
+    public void setLport(String lport) {
+        this.lport = lport;
+    }
+
+    public String getRport() {
+        return rport;
+    }
+
+    public void setRport(String rport) {
+        this.rport = rport;
+    }
+
+    public String getSshPort() {
+        return sshPort;
+    }
+
+    public void setSshPort(String sshPort) {
+        this.sshPort = sshPort;
+    }
+
+    public String getSshHost() {
+        return sshHost;
+    }
+
+    public void setSshHost(String sshHost) {
+        this.sshHost = sshHost;
+    }
+
+	public String getSshUser() {
+		return sshUser;
+	}
+
+	public void setSshUser(String sshUser) {
+		this.sshUser = sshUser;
+	}
+
+	public String getSshPassword() {
+		return sshPassword;
+	}
+
+	public void setSshPassword(String sshPassword) {
+		this.sshPassword = sshPassword;
+	}
+
 	@Override
 	public boolean equals(Object o) {
 		if (this == o) return true;
 		if (o == null || getClass() != o.getClass()) return false;
 		DatabaseConfig that = (DatabaseConfig) o;
-		return Objects.equals(dbType, that.dbType) && Objects.equals(name, that.name) && Objects.equals(host, that
-				.host) && Objects.equals(port, that.port) && Objects.equals(schema, that.schema) && Objects.equals
-				(username, that.username) && Objects.equals(password, that.password) && Objects.equals(encoding, that
-				.encoding);
+		return Objects.equals(id, that.id) &&
+				Objects.equals(dbType, that.dbType) &&
+				Objects.equals(name, that.name) &&
+				Objects.equals(host, that.host) &&
+				Objects.equals(port, that.port) &&
+				Objects.equals(schema, that.schema) &&
+				Objects.equals(username, that.username) &&
+				Objects.equals(password, that.password) &&
+				Objects.equals(encoding, that.encoding) &&
+				Objects.equals(lport, that.lport) &&
+				Objects.equals(rport, that.rport) &&
+				Objects.equals(sshPort, that.sshPort) &&
+				Objects.equals(sshHost, that.sshHost) &&
+				Objects.equals(sshUser, that.sshUser) &&
+				Objects.equals(sshPassword, that.sshPassword);
 	}
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(dbType, name, host, port, schema, username, password, encoding);
+		return Objects.hash(id, dbType, name, host, port, schema, username, password, encoding, lport, rport, sshPort, sshHost, sshUser, sshPassword);
 	}
 
 	@Override
 	public String toString() {
-		return "DatabaseConfig{" + "dbType='" + dbType + '\'' + ", name='" + name + '\'' + ", host='" + host + '\'' +
-				", port='" + port + '\'' + ", schema='" + schema + '\'' + ", username='" + username + '\'' + ", " +
-				"password='" + password + '\'' + ", encoding='" + encoding + '\'' + '}';
+		return "DatabaseConfig{" +
+				"id=" + id +
+				", dbType='" + dbType + '\'' +
+				", name='" + name + '\'' +
+				", host='" + host + '\'' +
+				", port='" + port + '\'' +
+				", schema='" + schema + '\'' +
+				", username='" + username + '\'' +
+				", password='" + password + '\'' +
+				", encoding='" + encoding + '\'' +
+				", lport='" + lport + '\'' +
+				", rport='" + rport + '\'' +
+				", sshPort='" + sshPort + '\'' +
+				", sshHost='" + sshHost + '\'' +
+				", sshUser='" + sshUser + '\'' +
+				", sshPassword='" + sshPassword + '\'' +
+				'}';
 	}
 }

--- a/src/main/java/com/zzg/mybatis/generator/util/DbUtil.java
+++ b/src/main/java/com/zzg/mybatis/generator/util/DbUtil.java
@@ -1,15 +1,22 @@
 package com.zzg.mybatis.generator.util;
 
+import com.jcraft.jsch.JSch;
+import com.jcraft.jsch.JSchException;
+import com.jcraft.jsch.Session;
 import com.zzg.mybatis.generator.exception.DbDriverLoadingException;
 import com.zzg.mybatis.generator.model.DatabaseConfig;
 import com.zzg.mybatis.generator.model.DbType;
 import com.zzg.mybatis.generator.model.UITableColumnVO;
+import com.zzg.mybatis.generator.view.AlertUtil;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.math.NumberUtils;
 import org.mybatis.generator.internal.util.ClassloaderUtility;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.sql.*;
 import java.util.*;
+import java.util.concurrent.*;
 
 /**
  * Created by Owen on 6/12/16.
@@ -20,6 +27,73 @@ public class DbUtil {
     private static final int DB_CONNECTION_TIMEOUTS_SECONDS = 1;
 
     private static Map<DbType, Driver> drivers = new HashMap<>();
+
+	private static ExecutorService executorService = Executors.newSingleThreadExecutor();
+	private static boolean portForwaring = false;
+
+    public static Session getSSHSession(DatabaseConfig databaseConfig) {
+		if (StringUtils.isBlank(databaseConfig.getSshHost())
+				|| StringUtils.isBlank(databaseConfig.getSshPort())
+				|| StringUtils.isBlank(databaseConfig.getSshUser())
+				|| StringUtils.isBlank(databaseConfig.getSshPassword())
+		) {
+			return null;
+		}
+		Session session = null;
+		try {
+			//Set StrictHostKeyChecking property to no to avoid UnknownHostKey issue
+			java.util.Properties config = new java.util.Properties();
+			config.put("StrictHostKeyChecking", "no");
+			JSch jsch = new JSch();
+			Integer sshPort = NumberUtils.createInteger(databaseConfig.getSshPort());
+			int port = sshPort == null ? 22 : sshPort;
+			session = jsch.getSession(databaseConfig.getSshUser(), databaseConfig.getSshHost(), port);
+			session.setPassword(databaseConfig.getSshPassword());
+			session.setConfig(config);
+		}catch (JSchException e) {
+			//Ignore
+		}
+		return session;
+	}
+
+	public static void engagePortForwarding(Session sshSession, DatabaseConfig config) {
+		if (sshSession != null) {
+			Future<?> result = executorService.submit(() -> {
+				try {
+					sshSession.connect();
+					Integer localPort = NumberUtils.createInteger(config.getLport());
+					Integer RemotePort = NumberUtils.createInteger(config.getRport());
+					int lport = localPort == null ? Integer.parseInt(config.getPort()) : localPort;
+					int rport = RemotePort == null ? Integer.parseInt(config.getPort()) : RemotePort;
+					int assinged_port = sshSession.setPortForwardingL(lport, config.getHost(), rport);
+					portForwaring = true;
+					_LOG.info("portForwarding Enabled, {}", assinged_port);
+				} catch (JSchException e) {
+					_LOG.error("Connect Over SSH failed", e);
+					throw new RuntimeException(e.getMessage());
+				}
+			});
+			try {
+				result.get(5, TimeUnit.SECONDS);
+			}catch (Exception e) {
+				sshSession.disconnect();
+				if (e instanceof TimeoutException) {
+					throw new RuntimeException("OverSSH 连接超时：超过5秒");
+				}
+				_LOG.info("executorService isShutdown:{}", executorService.isShutdown());
+				AlertUtil.showErrorAlert("OverSSH 失败，请检查连接设置:" + e.getMessage());
+			}
+		}
+	}
+
+	public static void shutdownPortForwarding(Session session) {
+		portForwaring = false;
+		if (session != null && session.isConnected()) {
+			session.disconnect();
+			_LOG.info("portForwarding turn OFF");
+		}
+//		executorService.shutdown();
+	}
 
     public static Connection getConnection(DatabaseConfig config) throws ClassNotFoundException, SQLException {
 		DbType dbType = DbType.valueOf(config.getDbType());
@@ -40,9 +114,9 @@ public class DbUtil {
     }
 
     public static List<String> getTableNames(DatabaseConfig config) throws Exception {
-        String url = getConnectionUrlWithSchema(config);
-        _LOG.info("getTableNames, connection url: {}", url);
-	    Connection connection = getConnection(config);
+		Session sshSession = getSSHSession(config);
+		engagePortForwarding(sshSession, config);
+		Connection connection = getConnection(config);
 	    try {
 		    List<String> tables = new ArrayList<>();
 		    DatabaseMetaData md = connection.getMetaData();
@@ -74,12 +148,15 @@ public class DbUtil {
 		    return tables;
 	    } finally {
 	    	connection.close();
+			shutdownPortForwarding(sshSession);
 	    }
 	}
 
     public static List<UITableColumnVO> getTableColumns(DatabaseConfig dbConfig, String tableName) throws Exception {
         String url = getConnectionUrlWithSchema(dbConfig);
         _LOG.info("getTableColumns, connection url: {}", url);
+		Session sshSession = getSSHSession(dbConfig);
+		engagePortForwarding(sshSession, dbConfig);
 		Connection conn = getConnection(dbConfig);
 		try {
 			DatabaseMetaData md = conn.getMetaData();
@@ -95,12 +172,14 @@ public class DbUtil {
 			return columns;
 		} finally {
 			conn.close();
+			shutdownPortForwarding(sshSession);
 		}
 	}
 
     public static String getConnectionUrlWithSchema(DatabaseConfig dbConfig) throws ClassNotFoundException {
 		DbType dbType = DbType.valueOf(dbConfig.getDbType());
-		String connectionUrl = String.format(dbType.getConnectionUrlPattern(), dbConfig.getHost(), dbConfig.getPort(), dbConfig.getSchema(), dbConfig.getEncoding());
+		String connectionUrl = String.format(dbType.getConnectionUrlPattern(),
+				portForwaring ? "127.0.0.1" : dbConfig.getHost(), portForwaring ? dbConfig.getLport() : dbConfig.getPort(), dbConfig.getSchema(), dbConfig.getEncoding());
         _LOG.info("getConnectionUrlWithSchema, connection url: {}", connectionUrl);
         return connectionUrl;
     }

--- a/src/main/resources/fxml/newConnection.fxml
+++ b/src/main/resources/fxml/newConnection.fxml
@@ -1,10 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
+<?import java.lang.String?>
 <?import javafx.collections.FXCollections?>
-<?import javafx.scene.control.*?>
-<?import javafx.scene.layout.*?>
-<?import java.lang.*?>
-<AnchorPane prefHeight="389.0" prefWidth="569.0" stylesheets="@../style.css" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1" fx:controller="com.zzg.mybatis.generator.controller.DbConnectionController">
+<?import javafx.scene.control.Button?>
+<?import javafx.scene.control.CheckBox?>
+<?import javafx.scene.control.ChoiceBox?>
+<?import javafx.scene.control.Label?>
+<?import javafx.scene.control.PasswordField?>
+<?import javafx.scene.control.TextField?>
+<?import javafx.scene.layout.AnchorPane?>
+<?import javafx.scene.layout.ColumnConstraints?>
+<?import javafx.scene.layout.GridPane?>
+<?import javafx.scene.layout.HBox?>
+<?import javafx.scene.layout.RowConstraints?>
+
+<AnchorPane prefHeight="389.0" prefWidth="569.0" stylesheets="@../style.css" xmlns="http://javafx.com/javafx/8.0.121" xmlns:fx="http://javafx.com/fxml/1" fx:controller="com.zzg.mybatis.generator.controller.DbConnectionController">
    <children>
       <GridPane alignment="CENTER_RIGHT" layoutX="10.0" layoutY="30.0" vgap="5.0" AnchorPane.leftAnchor="10.0" AnchorPane.rightAnchor="10.0">
         <columnConstraints>
@@ -72,6 +82,13 @@
                   <String fx:value="btn" />
                   <String fx:value="btn-default" />
                </styleClass></Button>
+
+           <Button layoutX="107.0" layoutY="6.0" mnemonicParsing="false" onAction="#overSSH" text="OverSSH" AnchorPane.bottomAnchor="5.0" AnchorPane.leftAnchor="100.0">
+             <styleClass>
+               <String fx:value="btn" />
+               <String fx:value="btn-default" />
+             </styleClass></Button>
+
           <Button layoutX="467.0" layoutY="12.0" mnemonicParsing="false" onAction="#saveConnection" prefHeight="28.0" prefWidth="61.0" text="保存" textFill="WHITE" AnchorPane.bottomAnchor="5.0" AnchorPane.rightAnchor="10.0">
                <styleClass>
                   <String fx:value="btn-success" />

--- a/src/main/resources/fxml/overssh.fxml
+++ b/src/main/resources/fxml/overssh.fxml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import java.lang.String?>
+<?import javafx.geometry.Insets?>
+<?import javafx.scene.control.Button?>
+<?import javafx.scene.control.Label?>
+<?import javafx.scene.control.PasswordField?>
+<?import javafx.scene.control.TextField?>
+<?import javafx.scene.layout.AnchorPane?>
+<?import javafx.scene.layout.ColumnConstraints?>
+<?import javafx.scene.layout.GridPane?>
+<?import javafx.scene.layout.RowConstraints?>
+
+<AnchorPane prefHeight="400.0" prefWidth="600.0" stylesheets="@../style.css" xmlns="http://javafx.com/javafx/8.0.121" xmlns:fx="http://javafx.com/fxml/1" fx:controller="com.zzg.mybatis.generator.controller.OverSshController">
+   <children>
+      <GridPane alignment="CENTER_RIGHT" maxHeight="200.0" maxWidth="600.0" minHeight="200.0" minWidth="600.0" nodeOrientation="LEFT_TO_RIGHT" prefHeight="200.0" prefWidth="600.0" AnchorPane.topAnchor="60.0">
+        <columnConstraints>
+          <ColumnConstraints hgrow="SOMETIMES" maxWidth="255.0" minWidth="42.0" prefWidth="184.0" />
+          <ColumnConstraints hgrow="SOMETIMES" maxWidth="213.0" minWidth="0.0" prefWidth="22.0" />
+            <ColumnConstraints hgrow="SOMETIMES" maxWidth="451.0" minWidth="243.0" prefWidth="394.0" />
+        </columnConstraints>
+        <rowConstraints>
+          <RowConstraints maxHeight="57.0" minHeight="10.0" prefHeight="43.0" vgrow="SOMETIMES" />
+          <RowConstraints maxHeight="56.0" minHeight="3.0" prefHeight="56.0" vgrow="SOMETIMES" />
+          <RowConstraints maxHeight="58.0" minHeight="10.0" prefHeight="41.0" vgrow="SOMETIMES" />
+            <RowConstraints maxHeight="45.0" minHeight="2.0" prefHeight="45.0" vgrow="SOMETIMES" />
+            <RowConstraints maxHeight="45.0" minHeight="10.0" prefHeight="45.0" vgrow="SOMETIMES" />
+            <RowConstraints maxHeight="45.0" minHeight="10.0" prefHeight="45.0" vgrow="SOMETIMES" />
+        </rowConstraints>
+         <children>
+            <Label alignment="CENTER_RIGHT" contentDisplay="RIGHT" text="目标端口" textAlignment="RIGHT" GridPane.halignment="RIGHT" GridPane.rowIndex="3">
+               <GridPane.margin>
+                  <Insets />
+               </GridPane.margin>
+            </Label>
+            <Label alignment="CENTER_RIGHT" contentDisplay="RIGHT" text="SSH主机名" GridPane.halignment="RIGHT" />
+            <Label alignment="CENTER_RIGHT" text="SSH端口" textAlignment="RIGHT" GridPane.halignment="RIGHT" GridPane.rowIndex="1" />
+            <Label text="本机端口" GridPane.halignment="RIGHT" GridPane.rowIndex="2" />
+            <TextField fx:id="hostField" maxWidth="200.0" GridPane.columnIndex="2" />
+            <TextField fx:id="sshdPortField" maxWidth="50.0" minWidth="50.0" prefWidth="50.0" GridPane.columnIndex="2" GridPane.rowIndex="1" />
+            <TextField fx:id="lportField" maxWidth="50.0" minWidth="50.0" prefWidth="50.0" GridPane.columnIndex="2" GridPane.rowIndex="2" />
+            <TextField fx:id="rportField" maxWidth="50.0" minWidth="50.0" prefWidth="50.0" GridPane.columnIndex="2" GridPane.rowIndex="3" />
+            <Label text="SSH用户名" GridPane.halignment="RIGHT" GridPane.rowIndex="4" />
+            <Label text="SSH密码" GridPane.halignment="RIGHT" GridPane.rowIndex="5" />
+            <TextField fx:id="sshUserField"  maxWidth="200.0" GridPane.columnIndex="2" GridPane.rowIndex="4" />
+            <PasswordField fx:id="sshPasswordField" maxWidth="200.0" GridPane.columnIndex="2" GridPane.rowIndex="5" />
+         </children>
+      </GridPane>
+      <AnchorPane prefHeight="100.0" prefWidth="600.0" AnchorPane.topAnchor="300.0">
+         <children>
+            <Button layoutX="107.0" layoutY="6.0" mnemonicParsing="false" onAction="#testSSH" text="测试连接" AnchorPane.bottomAnchor="20.0" AnchorPane.leftAnchor="30.0"><styleClass>
+              <String fx:value="btn" />
+              <String fx:value="btn-default" />
+            </styleClass></Button>
+           <Button layoutX="107.0" layoutY="6.0" mnemonicParsing="false" onAction="#reset" text="重置" AnchorPane.bottomAnchor="20.0" AnchorPane.leftAnchor="120.0"><styleClass>
+             <String fx:value="btn" />
+             <String fx:value="btn-default" />
+           </styleClass></Button>
+            <Button layoutX="107.0" layoutY="6.0" mnemonicParsing="false" onAction="#saveConfig" text="保存" AnchorPane.bottomAnchor="20.0" AnchorPane.rightAnchor="30.0"><styleClass>
+              <String fx:value="btn" />
+              <String fx:value="btn-success" />
+            </styleClass></Button>
+
+         </children></AnchorPane>
+   </children>
+</AnchorPane>

--- a/src/main/resources/fxml/overssh.fxml
+++ b/src/main/resources/fxml/overssh.fxml
@@ -42,11 +42,11 @@
             <TextField fx:id="rportField" maxWidth="50.0" minWidth="50.0" prefWidth="50.0" GridPane.columnIndex="2" GridPane.rowIndex="3" />
             <Label text="SSH用户名" GridPane.halignment="RIGHT" GridPane.rowIndex="4" />
             <Label text="SSH密码" GridPane.halignment="RIGHT" GridPane.rowIndex="5" />
-            <TextField fx:id="sshUserField"  maxWidth="200.0" GridPane.columnIndex="2" GridPane.rowIndex="4" />
+            <TextField fx:id="sshUserField" maxWidth="200.0" GridPane.columnIndex="2" GridPane.rowIndex="4" />
             <PasswordField fx:id="sshPasswordField" maxWidth="200.0" GridPane.columnIndex="2" GridPane.rowIndex="5" />
          </children>
       </GridPane>
-      <AnchorPane prefHeight="100.0" prefWidth="600.0" AnchorPane.topAnchor="300.0">
+      <AnchorPane layoutY="321.0" prefHeight="79.0" prefWidth="600.0" onMouseEntered="#checkInput" AnchorPane.topAnchor="321.0">
          <children>
             <Button layoutX="107.0" layoutY="6.0" mnemonicParsing="false" onAction="#testSSH" text="测试连接" AnchorPane.bottomAnchor="20.0" AnchorPane.leftAnchor="30.0"><styleClass>
               <String fx:value="btn" />
@@ -62,5 +62,10 @@
             </styleClass></Button>
 
          </children></AnchorPane>
+      <AnchorPane layoutY="271.0" minHeight="10.0" minWidth="600.0" prefHeight="50.0" prefWidth="200.0" AnchorPane.topAnchor="271.0">
+         <children>
+            <Label fx:id="note" alignment="CENTER" contentDisplay="CENTER" layoutX="191.0" layoutY="2.0" prefHeight="44.0" prefWidth="229.0" textAlignment="CENTER" textFill="#ff666f" />
+         </children>
+      </AnchorPane>
    </children>
 </AnchorPane>


### PR DESCRIPTION
与Navicat的OverSSH相似
说明
![image](https://user-images.githubusercontent.com/8142133/50555678-84c75200-0d0a-11e9-932f-84b3844ee343.png)

Case 1：填写不完整，SSH测试 报错弹窗
![image](https://user-images.githubusercontent.com/8142133/50555706-e1c30800-0d0a-11e9-9ed6-c7d9c50d42d0.png)

Case 2：填写完整，SSH测试地址不可达，超时报错弹窗
![image](https://user-images.githubusercontent.com/8142133/50555721-16cf5a80-0d0b-11e9-86ae-a232d435c1c0.png)

Case 3：填写完整，SSH地址可达，但是端口被拒绝
![image](https://user-images.githubusercontent.com/8142133/50555740-3c5c6400-0d0b-11e9-9b15-2f16aaa855e5.png)

Case 4：填写完整，SSH地址可达，启动OverSSH测试时，本地端口被占用，略：
解决方案：更换任意本地端口。

Case 5：填写不完整，可以保存，表示不开启OverSSH功能。

Case 6：新建连接时，直接点击OverSSH：填写后保存，实际不保存至数据库。但待填写数据库连接完成之后可以保存。

Case 7：在已有连接中，编辑连接，不改动，直接编辑OverSSH设置，点击保存，但不点击数据库连接页面的保存，OverSSH依然能够保存。
