### PR TITLE
修复长时间没有操作连接断开后，OverSSH动画不能关闭的问题

### DIFF
--- a/src/main/java/com/zzg/mybatis/generator/controller/PictureProcessStateController.java
+++ b/src/main/java/com/zzg/mybatis/generator/controller/PictureProcessStateController.java
@@ -106,6 +106,9 @@ public class PictureProcessStateController {
         if (showButton) {
             showCloseButton();
         }
+        if (!dialogStage.isShowing()) {
+            dialogStage.show();
+        }
     }
 
     private void showCloseButton() {


### PR DESCRIPTION
1. 修复 保存配置之后，再读取配置时，Dao 接口文件路径不正确的问题。
2. 修复长时间没有操作连接断开后，OverSSH动画不能关闭的问题。

1的复现方法：保存配置，然后应用配置，Dao接口的文件夹存放目录变成Dao的接口名。
2的复现方法：基于SSH的连接，在MainUIController中，手动制造连接断开异常。
```
bridge.generate();
throw CommunicationsException
```