### PR TITLE
优化主界面，优化应用配置时防止覆盖已选择的表

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ mybatis-generator-gui是基于 [mybatis generator](http://www.mybatis.org/genera
 
 ![overSSH](https://user-images.githubusercontent.com/3505708/51911646-5920b000-240d-11e9-9048-738306a56d14.png)
 
+![SearchSupport](https://user-images.githubusercontent.com/8142133/115959972-881d2200-a541-11eb-8ad4-052f379b91f1.png)
+
+
 ### 核心特性
 * 按照界面步骤轻松生成代码，省去XML繁琐的学习与配置过程
 * 保存数据库连接与Generator配置，每次代码生成轻松搞定

--- a/src/main/java/com/zzg/mybatis/generator/MainUI.java
+++ b/src/main/java/com/zzg/mybatis/generator/MainUI.java
@@ -6,6 +6,7 @@ import javafx.application.Application;
 import javafx.fxml.FXMLLoader;
 import javafx.scene.Parent;
 import javafx.scene.Scene;
+import javafx.scene.image.Image;
 import javafx.stage.Stage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -29,6 +30,9 @@ public class MainUI extends Application {
 		Parent root = fxmlLoader.load();
 		primaryStage.setResizable(true);
 		primaryStage.setScene(new Scene(root));
+		primaryStage.setTitle("Mybatis Generator GUI");
+		Image imageIcon = new Image("icons/mybatis-logo.png");
+		primaryStage.getIcons().add(imageIcon);
 		primaryStage.show();
 
 		MainUIController controller = fxmlLoader.getController();

--- a/src/main/java/com/zzg/mybatis/generator/controller/MainUIController.java
+++ b/src/main/java/com/zzg/mybatis/generator/controller/MainUIController.java
@@ -451,11 +451,13 @@ public class MainUIController extends BaseFXController {
         modelTargetProject.setText(generatorConfig.getModelPackageTargetFolder());
         daoTargetPackage.setText(generatorConfig.getDaoPackage());
 		daoTargetProject.setText(generatorConfig.getDaoTargetFolder());
-		mapperName.setText(generatorConfig.getMapperName());
 		mapperTargetPackage.setText(generatorConfig.getMappingXMLPackage());
         mappingTargetProject.setText(generatorConfig.getMappingXMLTargetFolder());
-        tableNameField.setText(generatorConfig.getTableName());
-        domainObjectNameField.setText(generatorConfig.getDomainObjectName());
+        if (StringUtils.isBlank(tableNameField.getText())) {
+            tableNameField.setText(generatorConfig.getTableName());
+            mapperName.setText(generatorConfig.getMapperName());
+            domainObjectNameField.setText(generatorConfig.getDomainObjectName());
+        }
         offsetLimitCheckBox.setSelected(generatorConfig.isOffsetLimit());
         commentCheckBox.setSelected(generatorConfig.isComment());
         overrideXML.setSelected(generatorConfig.isOverrideXML());
@@ -471,7 +473,6 @@ public class MainUIController extends BaseFXController {
         useDAOExtendStyle.setSelected(generatorConfig.isUseDAOExtendStyle());
         useSchemaPrefix.setSelected(generatorConfig.isUseSchemaPrefix());
         jsr310Support.setSelected(generatorConfig.isJsr310Support());
-
     }
 
     @FXML


### PR DESCRIPTION
关于第二点的操作说明：
1. 选择一张表 table_a, 双击选中。此时会自动生成表名，实体类名，接口名。
2. 选择一项配置(保存的时候是table_b)，应用后会覆盖当前选择的表，如果不注意看则会以为是 table_a

本次优化解决了这个问题。😊